### PR TITLE
Include support GitHub Enterprise Edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@
 People write different formats of repository url in package.json and sometimes there is even a typo.
 
 This module extracts the code from
-[npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses
-[normalize-package-data](https://github.com/npm/normalize-package-data) and
-[hosted-git-info](https://github.com/npm/hosted-git-info) and
-[bahmutov/parse-github-repo-url](https://github.com/bahmutov/parse-github-repo-url) to parse data. Please
-check them out for more details.
+[npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses [normalize-package-data](https://github.com/npm/normalize-package-data), [hosted-git-info](https://github.com/npm/hosted-git-info) and fallback to [bahmutov/parse-github-repo-url](https://github.com/bahmutov/parse-github-repo-url) to parse data. Please check them out for more details.
 
 **This module can fix some common [typos](typos.json).**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 
 People write different formats of repository url in package.json and sometimes there is even a typo.
 
-This module extracts the code from [npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses [normalize-package-data](https://github.com/npm/normalize-package-data) and [hosted-git-info](https://github.com/npm/hosted-git-info) to parse data. Please check them out for more details.
+This module extracts the code from
+[npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses
+[normalize-package-data](https://github.com/npm/normalize-package-data) and
+[hosted-git-info](https://github.com/npm/hosted-git-info) and
+[bahmutov/parse-github-repo-url](https://github.com/bahmutov/parse-github-repo-url) to parse data. Please
+check them out for more details.
 
 **This module can fix some common [typos](typos.json).**
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
 'use strict';
+var parseSlug = require('@bahmutov/parse-github-repo-url');
 var normalizeData = require('normalize-package-data');
 var hostedGitInfo = require('hosted-git-info');
 var url = require('url');
 var typos = require('./typos');
+
+var GenericRepo = function(repository) {
+  var slug = parseSlug(repository);
+  this.url = url.parse(repository);
+  this.user = slug[0];
+  this.project = slug[1];
+  this.committish = slug[2];
+};
+
+GenericRepo.prototype.browse = function() {
+  var protocol = this.url.protocol === 'https:' ? 'https:' : 'http:';
+  return protocol + '//' + (this.url.host || '') + this.url.path.replace(/\.git$/, '');
+};
 
 function unknownHostedInfo(repoUrl) {
   try {
@@ -10,16 +24,7 @@ function unknownHostedInfo(repoUrl) {
     if (index !== -1) {
       repoUrl = repoUrl.slice(index + 1).replace(/:([^\d]+)/, '/$1');
     }
-
-    var parsed = url.parse(repoUrl);
-
-    var Info = function() {};
-    Info.prototype.browse = function() {
-      var protocol = parsed.protocol === 'https:' ? 'https:' : 'http:';
-      return protocol + '//' + (parsed.host || '') + parsed.path.replace(/\.git$/, '');
-    };
-
-    return new Info();
+    return new GenericRepo(repoUrl);
   } catch (err) {}
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "repository"
   ],
   "dependencies": {
+    "@bahmutov/parse-github-repo-url": "^0.1.1",
     "hosted-git-info": "^2.1.4",
     "meow": "^3.3.0",
     "normalize-package-data": "^2.3.0",

--- a/test.js
+++ b/test.js
@@ -1,84 +1,67 @@
 'use strict';
 var assert = require('assert');
 var getPkgRepo = require('./');
+var parse = function(url, fix) {
+  return getPkgRepo({
+    repository: {url: url}
+  }, fix);
+};
 
 it('should parse github http', function() {
-  var repo = getPkgRepo({
-    repository: {
-      url: 'http://github.com/a/b'
-    }
-  });
+  var repo = parse('http://github.com/a/b');
 
   assert.equal(repo.browse(), 'https://github.com/a/b');
   assert.equal(repo.type, 'github');
 });
 
 it('should parse github https', function() {
-  var repo = getPkgRepo({
-    repository: {
-      url: 'https://github.com/a/b'
-    }
-  });
+  var repo = parse('https://github.com/a/b');
 
   assert.equal(repo.browse(), 'https://github.com/a/b');
   assert.equal(repo.type, 'github');
 });
 
 it('should parse github ssh', function() {
-  var repo = getPkgRepo({
-    repository: 'git@github.com:joyent/node.git'
-  });
+  var repo = parse('git@github.com:joyent/node.git');
 
   assert.equal(repo.browse(), 'https://github.com/joyent/node');
   assert.equal(repo.type, 'github');
 });
 
 it('should parse github short', function() {
-  var repo = getPkgRepo({
-    repository: 'a/b'
-  });
+  var repo = parse('a/b');
 
   assert.equal(repo.browse(), 'https://github.com/a/b');
   assert.equal(repo.type, 'github');
 });
 
 it('should parse bitbucket', function() {
-  var repo = getPkgRepo({
-    repository: 'https://bitbucket.org/a/b.git'
-  });
+  var repo = parse('https://bitbucket.org/a/b.git');
 
   assert.equal(repo.type, 'bitbucket');
   assert.equal(repo.browse(), 'https://bitbucket.org/a/b');
 });
 
 it('should parse svn', function() {
-  var repo = getPkgRepo({
-    repository: 'svn://a/b'
-  });
+  var repo = parse('svn://a/b');
 
   assert.equal(repo.browse(), 'http://a/b');
 });
 
 it('should parse https', function() {
-  var repo = getPkgRepo({
-    repository: 'https://a/b'
-  });
+  var repo = parse('https://a/b');
 
   assert.equal(repo.browse(), 'https://a/b');
 });
 
 it('should parse a url with an @', function() {
-  var repo = getPkgRepo({
-    repository: 'a@b.com'
-  });
+  var repo = parse('a@b.com');
 
   assert.equal(repo.browse(), 'http://b.com');
 });
 
 it('should fix bad protocal', function() {
-  var repo = getPkgRepo({
-    repository: 'badprotocol://a/b'
-  });
+  var repo = parse('badprotocol://a/b');
 
   assert.equal(repo.browse(), 'http://a/b');
 });
@@ -96,9 +79,7 @@ it('should work with a json', function() {
 });
 
 it('should work if there is a typo', function() {
-  var repo = getPkgRepo({
-    repo: 'a/b'
-  }, true);
+  var repo = getPkgRepo({repo: 'a/b'}, true);
 
   assert.equal(repo.browse(), 'https://github.com/a/b');
   assert.equal(repo.type, 'github');
@@ -108,4 +89,10 @@ it('should error if cannot get repository', function() {
   assert.throws(function() {
     getPkgRepo({});
   });
+});
+
+it('should parse github enterprise http url', function() {
+  var url = 'http://github.mycompany.dev/user/myRepo';
+  assert.equal(parse(url).browse(), 'http://github.mycompany.dev/user/myRepo');
+  assert.equal(parse(url).user, 'user');
 });

--- a/test.js
+++ b/test.js
@@ -7,63 +7,90 @@ var parse = function(url, fix) {
   }, fix);
 };
 
+var assertRepo = function(repo, expected) {
+  assert.equal(repo.browse(), expected.browse);
+  assert.equal(repo.type, expected.type);
+  assert.equal(repo.user, expected.user);
+  assert.equal(repo.project, expected.project);
+  assert.equal(repo.committish, expected.committish);
+};
+
 it('should parse github http', function() {
   var repo = parse('http://github.com/a/b');
-
-  assert.equal(repo.browse(), 'https://github.com/a/b');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/a/b',
+    type: 'github',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should parse github https', function() {
   var repo = parse('https://github.com/a/b');
-
-  assert.equal(repo.browse(), 'https://github.com/a/b');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/a/b',
+    type: 'github',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should parse github ssh', function() {
   var repo = parse('git@github.com:joyent/node.git');
-
-  assert.equal(repo.browse(), 'https://github.com/joyent/node');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/joyent/node',
+    type: 'github',
+    user: 'joyent',
+    project: 'node'
+  });
 });
 
 it('should parse github short', function() {
   var repo = parse('a/b');
-
-  assert.equal(repo.browse(), 'https://github.com/a/b');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/a/b',
+    type: 'github',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should parse bitbucket', function() {
   var repo = parse('https://bitbucket.org/a/b.git');
-
-  assert.equal(repo.type, 'bitbucket');
-  assert.equal(repo.browse(), 'https://bitbucket.org/a/b');
+  assertRepo(repo, {
+    browse: 'https://bitbucket.org/a/b',
+    type: 'bitbucket',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should parse svn', function() {
   var repo = parse('svn://a/b');
-
-  assert.equal(repo.browse(), 'http://a/b');
+  assertRepo(repo, {
+    browse: 'http://a/b'
+  });
 });
 
 it('should parse https', function() {
   var repo = parse('https://a/b');
-
-  assert.equal(repo.browse(), 'https://a/b');
+  assertRepo(repo, {
+    browse: 'https://a/b'
+  });
 });
 
 it('should parse a url with an @', function() {
   var repo = parse('a@b.com');
-
-  assert.equal(repo.browse(), 'http://b.com');
+  assertRepo(repo, {
+    browse: 'http://b.com'
+  });
 });
 
 it('should fix bad protocal', function() {
   var repo = parse('badprotocol://a/b');
-
-  assert.equal(repo.browse(), 'http://a/b');
+  assertRepo(repo, {
+    browse: 'http://a/b'
+  });
 });
 
 it('should work with a json', function() {
@@ -73,16 +100,22 @@ it('should work with a json', function() {
     }
   });
   var repo = getPkgRepo(jsonData);
-
-  assert.equal(repo.browse(), 'https://github.com/a/b');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/a/b',
+    type: 'github',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should work if there is a typo', function() {
   var repo = getPkgRepo({repo: 'a/b'}, true);
-
-  assert.equal(repo.browse(), 'https://github.com/a/b');
-  assert.equal(repo.type, 'github');
+  assertRepo(repo, {
+    browse: 'https://github.com/a/b',
+    type: 'github',
+    user: 'a',
+    project: 'b'
+  });
 });
 
 it('should error if cannot get repository', function() {
@@ -92,7 +125,12 @@ it('should error if cannot get repository', function() {
 });
 
 it('should parse github enterprise http url', function() {
-  var url = 'http://github.mycompany.dev/user/myRepo';
-  assert.equal(parse(url).browse(), 'http://github.mycompany.dev/user/myRepo');
-  assert.equal(parse(url).user, 'user');
+  var url = 'http://github.mycompany.dev/user/myRepo#123';
+  var repo = parse(url);
+  assertRepo(repo, {
+    browse: 'http://github.mycompany.dev/user/myRepo',
+    user: 'user',
+    project: 'myRepo',
+    committish: '123',
+  });
 });


### PR DESCRIPTION
Add dependency with [bahmutov/parse-github-repo-url](https://github.com/bahmutov/parse-github-repo-url) to fallback when impossible to parse using [npm/hosted-git-info](https://github.com/npm/hosted-git-info).

It adds support to Github Enterprise like urls.

Closes #3 