### PR TITLE
chore(dependencies): switch to original parse-github-repo-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 People write different formats of repository url in package.json and sometimes there is even a typo.
 
-This module extracts the code from [npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses [normalize-package-data](https://github.com/npm/normalize-package-data), [hosted-git-info](https://github.com/npm/hosted-git-info) and  [bahmutov/parse-github-repo-url](https://github.com/bahmutov/parse-github-repo-url) to parse data. Please check them out for more details.
+This module extracts the code from [npm/repo](https://github.com/npm/npm/blob/master/lib/repo.js), and uses [normalize-package-data](https://github.com/npm/normalize-package-data), [hosted-git-info](https://github.com/npm/hosted-git-info) and [parse-github-repo-url](https://github.com/repo-utils/parse-github-repo-url) to parse data. Please check them out for more details.
 
 **This module can fix some common [typos](typos.json).**
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var parseSlug = require('@bahmutov/parse-github-repo-url');
+var parseSlug = require('parse-github-repo-url');
 var normalizeData = require('normalize-package-data');
 var hostedGitInfo = require('hosted-git-info');
 var url = require('url');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "repository"
   ],
   "dependencies": {
-    "@bahmutov/parse-github-repo-url": "^0.1.1",
+    "parse-github-repo-url": "^1.2.0",
     "hosted-git-info": "^2.1.4",
     "meow": "^3.3.0",
     "normalize-package-data": "^2.3.0",


### PR DESCRIPTION
Fixes #5.

This should be all the changes necessary for the switch, however **version 1.2.0 of `parse-github-repo-url` hasn't been published yet** so CI will fail until it is. Meanwhile, this change will be waiting and ready to go.

This will remove deprecation warnings on install of `get-pkg-repo` and downstream dependents like `standard-version`.