### PR TITLE
feat(gitlab): parsing private gitlab repo urls, closes #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-pkg-repo",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Get normalized repository from package json data",
   "homepage": "https://github.com/stevemao/get-pkg-repo",
   "author": {
@@ -31,7 +31,7 @@
     "repository"
   ],
   "dependencies": {
-    "parse-github-repo-url": "^1.2.0",
+    "parse-github-repo-url": "^1.3.0",
     "hosted-git-info": "^2.1.4",
     "meow": "^3.3.0",
     "normalize-package-data": "^2.3.0",

--- a/test.js
+++ b/test.js
@@ -48,6 +48,17 @@ it('should parse github ssh', function() {
   });
 });
 
+it('should parse private gitlab ssh', function() {
+  var repo = parse('git@gitlab.team.com:username/test.git');
+  assertRepo(repo, {
+    browse: 'https://gitlab.team.com/username/test',
+    domain: 'gitlab.team.com',
+    type: 'gitlab',
+    user: 'username',
+    project: 'test'
+  });
+});
+
 it('should parse github short', function() {
   var repo = parse('a/b');
   assertRepo(repo, {
@@ -141,7 +152,8 @@ it('should parse github enterprise http url', function() {
     browse: 'http://github.mycompany.dev/user/myRepo',
     domain: 'github.mycompany.dev',
     user: 'user',
-    project: 'myRepo'
+    project: 'myRepo',
+    type: 'github'
   });
 });
 


### PR DESCRIPTION
Adds support for `git@gitlab.company.com...` urls