### PR TITLE
Fallback to repository.type if type is valid and autodetection fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function getType(repo) {
   if (repo.url.indexOf('gitlab') !== -1) {
     return 'gitlab';
   }
-  if (repo.type == 'github' || repo.type == 'gitlab' ) {
+  if (repo.type === 'github' || repo.type === 'gitlab' ) {
     return repo.type;
   }
 }

--- a/index.js
+++ b/index.js
@@ -24,22 +24,25 @@ function parseRepoUrl(repoUrl) {
   return parsed;
 }
 
-function getType(repoUrl) {
-  if (repoUrl.indexOf('github') !== -1) {
+function getType(repo) {
+  if (repo.url.indexOf('github') !== -1) {
     return 'github';
   }
-  if (repoUrl.indexOf('gitlab') !== -1) {
+  if (repo.url.indexOf('gitlab') !== -1) {
     return 'gitlab';
+  }
+  if (repo.type == 'github' || repo.type == 'gitlab' ) {
+    return repo.type;
   }
 }
 
-function unknownHostedInfo(repoUrl) {
-  var parsed = parseRepoUrl(repoUrl);
+function unknownHostedInfo(repo) {
+  var parsed = parseRepoUrl(repo.url);
   var protocol = parsed.protocol === 'https:' ? 'https:' : 'http:';
   var browseUrl = protocol + '//' + (parsed.host || '') + parsed.path.replace(/\.git$/, '').replace(/\/$/, '');
 
   var UnknownGitHost = function() {
-    var slug = parseSlug(repoUrl);
+    var slug = parseSlug(repo.url);
 
     if (parsed.host) {
       this.domain = parsed.host;
@@ -48,7 +51,7 @@ function unknownHostedInfo(repoUrl) {
     this.user = slug[0];
     this.project = slug[1];
 
-    this.type = getType(repoUrl);
+    this.type = getType(repo);
   };
 
   UnknownGitHost.prototype.browse = function() {
@@ -79,7 +82,7 @@ function getPkgRepo(pkgData, fixTypo) {
       ' Please see https://docs.npmjs.com/files/package.json#repository for proper syntax.');
   }
 
-  return hostedGitInfo.fromUrl(repo.url) || unknownHostedInfo(repo.url);
+  return hostedGitInfo.fromUrl(repo.url) || unknownHostedInfo(repo);
 }
 
 module.exports = getPkgRepo;

--- a/test.js
+++ b/test.js
@@ -128,6 +128,50 @@ it('should work with a json', function() {
   });
 });
 
+it('should fallback to repository.type if valid', function() {
+  var jsonData = JSON.stringify({
+    repository: {
+      url: 'http://private.com/',
+      type: 'gitlab'
+    }
+  });
+  var repo = getPkgRepo(jsonData);
+  assertRepo(repo, {
+    browse: 'https://private.com/',
+    domain: 'private.com',
+    type: 'gitlab'
+  });
+});
+
+it('should not fallback to repository.type if invalid', function() {
+  var jsonData = JSON.stringify({
+    repository: {
+      url: 'http://private.com/',
+      type: 'garbage'
+    }
+  });
+  var repo = getPkgRepo(jsonData);
+  assertRepo(repo, {
+    browse: 'https://private.com/',
+    domain: 'private.com'
+  });
+});
+
+it('should override repository.type if autodetection works', function() {
+  var jsonData = JSON.stringify({
+    repository: {
+      url: 'http://github.com/',
+      type: 'gitlab'
+    }
+  });
+  var repo = getPkgRepo(jsonData);
+  assertRepo(repo, {
+    browse: 'https://private.com/',
+    domain: 'private.com',
+    type: 'github'
+  });
+});
+
 it('should work if there is a typo', function() {
   var repo = getPkgRepo({repo: 'a/b'}, true);
   assertRepo(repo, {


### PR DESCRIPTION
If autodetection of the repository type fails on repo.url, instead of returning `null`, return repo.type if it's a valid type.

This is an implementation of what I proposed in [#258](https://github.com/conventional-changelog/conventional-changelog/pull/258) on conventional-changelog. This would allow a repository type to be defined in cases where it cannot be autodetected by url.