### PR TITLE
refactor(typos): move into source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module extracts the code from the [npm package manager](https://github.com/
 
 If you are interested, please check those other packages for more details.
 
-For more information on which typos can be handled, please see [typos.json](typos.json).
+Common misspelling of the [repository](https://docs.npmjs.com/files/package.json#repository) field are also corrected (Please see the source code for available corrections.).
 
 **This module mutates/normalizes the input using `normalize-package-data`.**
 
@@ -83,7 +83,9 @@ Contents of `pkgData` are mutated/normalized by `normalize-package-data`.
 
 Type: `boolean`
 
-If you want to fix your typical typos automatically, pass true. See [the list of predefined typos](typos.json).
+If you want to fix your typical typos automatically pass `true`.
+
+> Please keep in mind that this feature may be removed in the future. The [`repository`](https://docs.npmjs.com/files/package.json#repository) field in `package.json` is well documented and it should be correctly spelled.
 
 ## CLI
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var parseSlug = require('parse-github-repo-url');
 var normalizeData = require('normalize-package-data');
 var hostedGitInfo = require('hosted-git-info');
 var url = require('url');
-var typos = require('./typos');
+var typos = ['repostitory', 'repostitorys', 'repositories', 'repostitories', 'repositorys', 'repo', 'repos'];
 
 var gitAt = /^git@/;
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "cli.js",
-    "typos.json"
+    "cli.js"
   ],
   "keywords": [
     "get-pkg-repo",

--- a/typos.json
+++ b/typos.json
@@ -1,1 +1,0 @@
-["repostitory", "repostitorys", "repositories", "repostitories", "repositorys", "repo", "repos"]


### PR DESCRIPTION
Move the `typos.json` list into the JavaScript source code
so that consumers of this package aren't forced to process the JSON
file when using bundlers.

This also simplifies the package just a little, and helps move us
towards removing typo support at a future date.

BREAKING CHANGE:

`typos.json` has been removed.

Any direct consumption of the JSON file will will be impossible.

Fixes #14